### PR TITLE
Add library completion for Python modules

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -133,6 +133,9 @@ namespace xrob
             kernel_res["status"] = "ok";
             kernel_res["user_expressions"] = nl::json::object();
             kernel_res["payload"] = nl::json::array();
+
+            // Keep the Python module name around for library completion
+            m_python_modules.attr("append")(module_name);
         }
         catch (py::error_already_set& e)
         {
@@ -182,7 +185,7 @@ namespace xrob
 
         py::module robot_interpreter = py::module::import("robotframework_interpreter");
 
-        return robot_interpreter.attr("complete")(code, cursor_pos, m_test_suite, m_keywords_listener);
+        return robot_interpreter.attr("complete")(code, cursor_pos, m_test_suite, m_keywords_listener, m_python_modules);
     }
 
     nl::json interpreter::inspect_request_impl(const std::string& /*code*/,

--- a/src/xinterpreter.hpp
+++ b/src/xinterpreter.hpp
@@ -58,6 +58,7 @@ namespace xrob
         py::object m_test_suite;
         py::object m_keywords_listener;
         py::list m_listener;
+        py::list m_python_modules;
         py::object m_debug_adapter;
     };
 }


### PR DESCRIPTION

![python_lib](https://user-images.githubusercontent.com/21197331/101327059-7119b400-386e-11eb-8346-eeb6b645939a.gif)
This is built against https://github.com/jupyter-xeus/robotframework-interpreter/pull/10, we should wait for a robotframework-interpreter release.