### PR TITLE
Fix README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/__pycache__/
 build/*
 share/jupyter/kernels/xrobot/kernel.json
 notebooks/.ipynb_checkpoints/*
+*Untitled*.ipynb*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ### Using conda
 
 ```bash
-conda install -c conda-forge
+conda install -c conda-forge xeus-robot
 ```
 
 ### Installing from source
@@ -19,7 +19,7 @@ conda install -c conda-forge
 You can install `xeus-robot` from the sources, you first need to install its dependencies:
 
 ```bash
-conda install -c conda-forge xeus-python xtl cmake cppzmq nlohmann_json pybind11 pybind11_json robotframework robotframework-interpreter
+conda install -c conda-forge xeus-python xtl cmake cppzmq nlohmann_json pybind11 pybind11_json robotframework-interpreter
 ```
 
 Then you can compile the sources:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,6 @@ dependencies:
   - pybind11
   - pybind11_json
   - pip
-  - robotframework
   - robotframework-interpreter==0.2.0
   # Test dependencies
   - pytest


### PR DESCRIPTION
Also removing `robotframework` from the dependencies, we should let `robotframework-interpreter` bring the right version