### PR TITLE
Add jupyterlab_robotmode to install intructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ conda install -c conda-forge xeus-robot
 You can install `xeus-robot` from the sources, you first need to install its dependencies:
 
 ```bash
-conda install -c conda-forge xeus-python xtl cmake cppzmq nlohmann_json pybind11 pybind11_json robotframework-interpreter
+conda install -c conda-forge xeus-python xtl cmake cppzmq nlohmann_json pybind11 pybind11_json robotframework-interpreter jupyterlab_robotmode
 ```
 
 Then you can compile the sources:


### PR DESCRIPTION
Just adding it to the dev install instructions, because I will add it as a dependency in the conda recipe so it's not needed when installing from conda.

Not adding it to the dependency table, because it's a really soft dependency, it's there just for convenience but it not actually needed by the package.