### PR TITLE
Remove usage of RpaBrowserConnectionsListener

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -80,7 +80,6 @@ namespace xrob
         m_status_listener = robot_interpreter.attr("StatusEventListener")();
         m_listeners.append(m_status_listener);
 
-        m_listeners.append(robot_interpreter.attr("RpaBrowserConnectionsListener")(m_drivers));
         m_listeners.append(robot_interpreter.attr("SeleniumConnectionsListener")(m_drivers));
         m_listeners.append(robot_interpreter.attr("JupyterConnectionsListener")(m_drivers));
         m_listeners.append(robot_interpreter.attr("AppiumConnectionsListener")(m_drivers));


### PR DESCRIPTION
The listener has been merged with SeleniumConnectionsListener and will be removed from robotframework-interpreter.

Required change after: https://github.com/jupyter-xeus/robotframework-interpreter/pull/44